### PR TITLE
CVSS v3.0 parsing support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 //! Common Vulnerability Scoring System.
 //!
-//! The [cvss::v3::Base](v3/base/struct.Base.html) type provides the main functionality presently
-//! implemented by this crate, namely: support for parsing, serializing, and
-//! scoring `CVSS:3.1` Base Metric Group vector strings as described in
-//! the CVSS v3.1 Specification:
+//! The [cvss::v3::Base](v3/base/struct.Base.html) type provides the main
+//! functionality presently implemented by this crate, namely: support for
+//! parsing, serializing, and scoring `CVSS:3.0` and `CVSS:3.1`
+//! Base Metric Group vector strings as described in the CVSS v3.1 Specification:
 //!
 //! <https://www.first.org/cvss/specification-document>
 //!

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -10,5 +10,8 @@ pub mod score;
 
 pub use self::{base::Base, metric::Metric, score::Score};
 
-/// Supported CVSS v3 version
-pub const VERSION: &str = "3.1";
+/// Current CVSS v3 version supported by this library
+const CURRENT_VERSION: &str = "3.1";
+
+/// Supported CVSS v3 versions
+const SUPPORTED_VERSIONS: &[&str] = &["3.0", "3.1"];

--- a/src/v3/base.rs
+++ b/src/v3/base.rs
@@ -9,7 +9,7 @@ pub mod pr;
 pub mod s;
 pub mod ui;
 
-use super::{metric::Metric, Score, VERSION};
+use super::{metric::Metric, Score, CURRENT_VERSION, SUPPORTED_VERSIONS};
 use crate::{
     error::{Error, ErrorKind},
     Severity, PREFIX,
@@ -176,7 +176,7 @@ macro_rules! write_metrics {
 
 impl fmt::Display for Base {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", PREFIX, VERSION)?;
+        write!(f, "{}:{}", PREFIX, CURRENT_VERSION)?;
         write_metrics!(f, self.av, self.ac, self.pr, self.ui, self.s, self.c, self.i, self.a);
         Ok(())
     }
@@ -219,10 +219,14 @@ impl FromStr for Base {
                 fail!(ErrorKind::Parse, "invalid CVSS prefix: {}", id);
             }
 
-            if version != VERSION {
+            if !SUPPORTED_VERSIONS
+                .iter()
+                .any(|supported_version| supported_version == &version)
+            {
                 fail!(
                     ErrorKind::Version,
-                    "wrong CVSS version (expected 3.1): '{}'",
+                    "wrong CVSS version (expected one of {}): '{}'",
+                    SUPPORTED_VERSIONS.join(", "),
                     version
                 );
             }

--- a/tests/base.rs
+++ b/tests/base.rs
@@ -20,6 +20,14 @@ fn bad_prefix() {
     assert!(cvss::v3::Base::from_str(cvss_for_cve_2013_1937e).is_err());
 }
 
+/// CVSS:3.0 prefix (parse these as for the purposes of this library they're identical)
+#[test]
+fn cvss_v3_0_prefix() {
+    let cvss_for_cve_2013_1937 = "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N";
+    let base = cvss::v3::Base::from_str(cvss_for_cve_2013_1937).unwrap();
+    assert_eq!(base.score().value(), 6.1);
+}
+
 /// CVE-2013-0375
 #[test]
 fn cve_2013_0375() {


### PR DESCRIPTION
Support for parsing CVSS vectors with a "CVSS:3.0" prefix. For what we support (Base Metrics) these are identical to CVSS v3.1.